### PR TITLE
remove day_after_tomorrow from weather-report command #3

### DIFF
--- a/bin/weather-report
+++ b/bin/weather-report
@@ -40,7 +40,7 @@ end
 city = opt_parser.parse(ARGV)
 weather = WeatherReport::Weather.new(WeatherReport::Weather.request_cityid(*city))
 
-[weather.today, weather.tomorrow, weather.day_after_tomorrow].each do |day|
+[weather.today, weather.tomorrow].each do |day|
   print "#{day.date.year}年#{day.date.month}月#{day.date.day}日の天気 #{day.telop}"
   print " 最低気温#{day.temperature_min}度" if day.temperature_min
   print " 最高気温#{day.temperature_max}度" if day.temperature_max


### PR DESCRIPTION
#3 のための修正です

明後日の天気がlivedoor weatherのAPIから削除されたので、weather-reportコマンドで明後日の天気を取得するのをやめました。

<img src="http://gyazo.com/d1b91c8678ac22e9a34ffef63473b9dd.png">
